### PR TITLE
Fix the waker lists growing indefinitely.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
+# main
+* Fix bug where the list of wakers to trigger on shutdown or shutdown completion could grow indefinitely.
+
 # Version 0.2.1 - 2023-10-08
-* Fix `ShutdownManager::wait_shutdown_complete()` never completing if callend when no shutdown was triggered yet and no delay tokens exist.
+* Fix `ShutdownManager::wait_shutdown_complete()` never completing if called when no shutdown was triggered yet and no delay tokens exist.
 
 # Version 0.2.0 - 2023-09-26:
 * Rename `Shutdown` struct to `ShutdownManager`.

--- a/src/shutdown_complete.rs
+++ b/src/shutdown_complete.rs
@@ -3,11 +3,33 @@ use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
 
+use crate::waker_list::WakerToken;
 use crate::ShutdownManagerInner;
 
 /// Future to wait for a shutdown to complete.
 pub struct ShutdownComplete<T: Clone> {
 	pub(crate) inner: Arc<Mutex<ShutdownManagerInner<T>>>,
+	pub(crate) waker_token: Option<WakerToken>,
+}
+
+impl<T: Clone> Clone for ShutdownComplete<T> {
+	fn clone(&self) -> Self {
+		// Clone only the reference to the shutdown manager, not the waker token.
+		// The waker token is personal to each future.
+		Self {
+			inner: self.inner.clone(),
+			waker_token: None,
+		}
+	}
+}
+
+impl<T: Clone> Drop for ShutdownComplete<T> {
+	fn drop(&mut self) {
+		if let Some(token) = self.waker_token.take() {
+			let mut inner = self.inner.lock().unwrap();
+			inner.on_shutdown_complete.deregister(token);
+		}
+	}
 }
 
 impl<T: Clone> Future for ShutdownComplete<T> {
@@ -15,18 +37,103 @@ impl<T: Clone> Future for ShutdownComplete<T> {
 
 	#[inline]
 	fn poll(self: Pin<&mut Self>, context: &mut Context) -> Poll<Self::Output> {
-		let me = self.as_ref();
+		let me = self.get_mut();
 		let mut inner = me.inner.lock().unwrap();
+
+		// We're being polled, so we should deregister the waker (if any).
+		if let Some(token) = me.waker_token.take() {
+			inner.on_shutdown_complete.deregister(token);
+		}
+
+		// Check if the shutdown is completed.
 		if inner.delay_tokens == 0 {
 			if let Some(reason) = inner.shutdown_reason.clone() {
-				Poll::Ready(reason)
-			} else {
-				inner.on_shutdown_complete.push(context.waker().clone());
-				Poll::Pending
+				return Poll::Ready(reason);
 			}
-		} else {
-			inner.on_shutdown_complete.push(context.waker().clone());
-			Poll::Pending
+		}
+
+		// We're not ready, so register the waker to wake us on shutdown completion.
+		me.waker_token = Some(inner.on_shutdown_complete.register(context.waker().clone()));
+
+		Poll::Pending
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use assert2::assert;
+	use std::future::Future;
+	use std::pin::Pin;
+	use std::task::Poll;
+
+	/// Wrapper around a future to poll it only once.
+	struct PollOnce<'a, F>(&'a mut F);
+
+	impl<'a, F: std::marker::Unpin + Future> Future for PollOnce<'a, F> {
+		type Output = Poll<F::Output>;
+
+		fn poll(self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
+			Poll::Ready(Pin::new(&mut self.get_mut().0).poll(cx))
+		}
+	}
+
+	/// Poll a future once.
+	async fn poll_once<F: Future + Unpin>(future: &mut F) -> Poll<F::Output> {
+		PollOnce(future).await
+	}
+
+	#[tokio::test]
+	async fn waker_list_doesnt_grow_infinitely() {
+		let shutdown = crate::ShutdownManager::<()>::new();
+		for i in 0..100_000 {
+			let mut wait_shutdown_complete = shutdown.wait_shutdown_complete();
+			let task = tokio::spawn(async move {
+				assert!(let Poll::Pending = poll_once(&mut wait_shutdown_complete).await);
+			});
+			assert!(let Ok(()) = task.await, "task = {i}");
+		}
+
+		// Since we wait for each task to complete before spawning another,
+		// the total amount of waker slots used should be only 1.
+		let inner = shutdown.inner.lock().unwrap();
+		assert!(inner.on_shutdown_complete.total_slots() == 1);
+		assert!(inner.on_shutdown_complete.empty_slots() == 1);
+	}
+
+	#[tokio::test]
+	async fn cloning_does_not_clone_waker_token() {
+		let shutdown = crate::ShutdownManager::<()>::new();
+
+		let mut signal = shutdown.wait_shutdown_complete();
+		assert!(let None = &signal.waker_token);
+
+		assert!(let Poll::Pending = poll_once(&mut signal).await);
+		assert!(let Some(_) = &signal.waker_token);
+
+		let mut cloned = signal.clone();
+		assert!(let None = &cloned.waker_token);
+		assert!(let Some(_) = &signal.waker_token);
+
+		assert!(let Poll::Pending = poll_once(&mut cloned).await);
+		assert!(let Some(_) = &cloned.waker_token);
+		assert!(let Some(_) = &signal.waker_token);
+
+		{
+			let inner = shutdown.inner.lock().unwrap();
+			assert!(inner.on_shutdown_complete.total_slots() == 2);
+			assert!(inner.on_shutdown_complete.empty_slots() == 0);
+		}
+
+		{
+			drop(signal);
+			let inner = shutdown.inner.lock().unwrap();
+			assert!(inner.on_shutdown_complete.empty_slots() == 1);
+		}
+
+		{
+			drop(cloned);
+			let inner = shutdown.inner.lock().unwrap();
+			assert!(inner.on_shutdown_complete.empty_slots() == 2);
 		}
 	}
 }

--- a/src/shutdown_signal.rs
+++ b/src/shutdown_signal.rs
@@ -3,6 +3,7 @@ use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
 
+use crate::waker_list::WakerToken;
 use crate::{WrapCancel, ShutdownManagerInner};
 
 /// A future to wait for a shutdown signal.
@@ -10,9 +11,29 @@ use crate::{WrapCancel, ShutdownManagerInner};
 /// The future completes when the associated [`ShutdownManager`][crate::ShutdownManager] triggers a shutdown.
 ///
 /// The shutdown signal can be cloned and sent between threads freely.
-#[derive(Clone)]
 pub struct ShutdownSignal<T: Clone> {
 	pub(crate) inner: Arc<Mutex<ShutdownManagerInner<T>>>,
+	pub(crate) waker_token: Option<WakerToken>,
+}
+
+impl<T: Clone> Clone for ShutdownSignal<T> {
+	fn clone(&self) -> Self {
+		// Clone only the reference to the shutdown manager, not the waker token.
+		// The waker token is personal to each future.
+		Self {
+			inner: self.inner.clone(),
+			waker_token: None,
+		}
+	}
+}
+
+impl<T: Clone> Drop for ShutdownSignal<T> {
+	fn drop(&mut self) {
+		if let Some(token) = self.waker_token.take() {
+			let mut inner = self.inner.lock().unwrap();
+			inner.on_shutdown.deregister(token);
+		}
+	}
 }
 
 impl<T: Clone> ShutdownSignal<T> {
@@ -36,13 +57,99 @@ impl<T: Clone> Future for ShutdownSignal<T> {
 
 	#[inline]
 	fn poll(self: Pin<&mut Self>, context: &mut Context) -> Poll<Self::Output> {
-		let me = self.as_ref();
+		let me = self.get_mut();
 		let mut inner = me.inner.lock().unwrap();
+
+		// We're being polled, so we should deregister the waker (if any).
+		if let Some(token) = me.waker_token.take() {
+			inner.on_shutdown.deregister(token);
+		}
+
 		if let Some(reason) = inner.shutdown_reason.clone() {
+			// Shutdown started, so we're ready.
 			Poll::Ready(reason)
 		} else {
-			inner.on_shutdown.push(context.waker().clone());
+			// We're not ready, so register the waker to wake us on shutdown start.
+			me.waker_token = Some(inner.on_shutdown.register(context.waker().clone()));
 			Poll::Pending
+		}
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use assert2::assert;
+	use std::future::Future;
+	use std::pin::Pin;
+	use std::task::Poll;
+
+	/// Wrapper around a future to poll it only once.
+	struct PollOnce<'a, F>(&'a mut F);
+
+	impl<'a, F: std::marker::Unpin + Future> Future for PollOnce<'a, F> {
+		type Output = Poll<F::Output>;
+
+		fn poll(self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
+			Poll::Ready(Pin::new(&mut self.get_mut().0).poll(cx))
+		}
+	}
+
+	/// Poll a future once.
+	async fn poll_once<F: Future + Unpin>(future: &mut F) -> Poll<F::Output> {
+		PollOnce(future).await
+	}
+
+	#[tokio::test]
+	async fn waker_list_doesnt_grow_infinitely() {
+		let shutdown = crate::ShutdownManager::<()>::new();
+		for i in 0..100_000 {
+			let task = tokio::spawn(shutdown.wrap_cancel(async move {
+				tokio::task::yield_now().await;
+			}));
+			assert!(let Ok(Ok(())) = task.await, "task = {i}");
+		}
+
+		// Since we wait for each task to complete before spawning another,
+		// the total amount of waker slots used should be only 1.
+		let inner = shutdown.inner.lock().unwrap();
+		assert!(inner.on_shutdown.total_slots() == 1);
+		assert!(inner.on_shutdown.empty_slots() == 1);
+	}
+
+	#[tokio::test]
+	async fn cloning_does_not_clone_waker_token() {
+		let shutdown = crate::ShutdownManager::<()>::new();
+
+		let mut signal = shutdown.wait_shutdown_triggered();
+		assert!(let None = &signal.waker_token);
+
+		assert!(let Poll::Pending = poll_once(&mut signal).await);
+		assert!(let Some(_) = &signal.waker_token);
+
+		let mut cloned = signal.clone();
+		assert!(let None = &cloned.waker_token);
+		assert!(let Some(_) = &signal.waker_token);
+
+		assert!(let Poll::Pending = poll_once(&mut cloned).await);
+		assert!(let Some(_) = &cloned.waker_token);
+		assert!(let Some(_) = &signal.waker_token);
+
+		{
+			let inner = shutdown.inner.lock().unwrap();
+			assert!(inner.on_shutdown.total_slots() == 2);
+			assert!(inner.on_shutdown.empty_slots() == 0);
+		}
+
+		{
+			drop(signal);
+			let inner = shutdown.inner.lock().unwrap();
+			assert!(inner.on_shutdown.empty_slots() == 1);
+		}
+
+		{
+			drop(cloned);
+			let inner = shutdown.inner.lock().unwrap();
+			assert!(inner.on_shutdown.empty_slots() == 2);
 		}
 	}
 }

--- a/src/waker_list.rs
+++ b/src/waker_list.rs
@@ -1,0 +1,93 @@
+use std::task::Waker;
+
+/// A list of wakers.
+#[derive(Debug, Default)]
+pub struct WakerList {
+	/// The wakers (with possibly empty slots)
+	wakers: Vec<Option<Waker>>,
+
+	/// The empty slots in the list.
+	empty_slots: Vec<usize>,
+
+	/// The current epoch, increased whenever `wake_all` is called.
+	epoch: usize,
+}
+
+pub struct WakerToken {
+	epoch: usize,
+	index: usize,
+}
+
+impl WakerList {
+	/// Create a new empty list of wakers.
+	pub fn new() -> Self {
+		Self::default()
+	}
+
+	/// Register a waker to be woken up when `wake_all` is called.
+	///
+	/// Returns a token that can be used to unregister the waker again.
+	pub fn register(&mut self, waker: Waker) -> WakerToken {
+		if let Some(index) = self.empty_slots.pop() {
+			debug_assert!(self.wakers[index].is_none());
+			self.wakers[index] = Some(waker);
+			self.token(index)
+		} else {
+			self.wakers.push(Some(waker));
+			self.token(self.wakers.len() - 1)
+		}
+	}
+
+	/// Deregister a waker so it will not be woken up by `wake_all` any more.
+	///
+	/// This should be called when a future that registered the waker is dropped,
+	/// to prevent the list of wakers growing infinitely large.
+	///
+	/// # Panic
+	/// May panic now or later if you give this function a token from another [`WakerList`].
+	pub fn deregister(&mut self, token: WakerToken) -> Option<Waker> {
+		if self.epoch != token.epoch {
+			None
+		} else if let Some(waker) = self.wakers[token.index].take() {
+			self.empty_slots.push(token.index);
+			Some(waker)
+		} else {
+			None
+		}
+	}
+
+	/// Wake all wakers, clear the list and increase the epoch.
+	#[allow(clippy::manual_flatten)] // Ssssh.
+	pub fn wake_all(&mut self) {
+		for waker in &mut self.wakers {
+			if let Some(waker) = waker.take() {
+				waker.wake()
+			}
+		}
+		self.wakers.clear();
+		self.empty_slots.clear();
+		self.epoch += 1;
+	}
+
+	/// Create a token for the current epoch with the given index.
+	fn token(&self, index: usize) -> WakerToken {
+		WakerToken {
+			epoch: self.epoch,
+			index,
+		}
+	}
+
+	/// Get the total number of waker slots.
+	///
+	/// This includes empty slots.
+	#[cfg(test)]
+	pub fn total_slots(&self) -> usize {
+		self.wakers.len()
+	}
+
+	/// Get the number of empty waker slots.
+	#[cfg(test)]
+	pub fn empty_slots(&self) -> usize {
+		self.empty_slots.len()
+	}
+}


### PR DESCRIPTION
This PR removes wakers from the waker list when the future that registered the waker is dropped.

Should fix #7.

@hellertime: Do you want to verify if this fixed your issue?

You should be able to test it with:
```toml
[dependencies]
async-shutdown = { git = "https://github.com/de-vri-es/async-shutdown-rs", branch = "fix-waker-list-growing-indefinitely" }
```