### PR TITLE
optional single-thread runtime compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,15 @@ categories = ["asynchronous"]
 
 edition = "2018"
 
+[features]
+default = ["multi-thread"]
+multi-thread = ["tokio/rt-multi-thread"]
+
+[[example]]
+name = "tcp-echo-server"
+required-features = ["multi-thread"]
+
 [dev-dependencies]
 assert2 = "0.3.4"
-tokio = { version = "1.12.0", features = ["io-util", "macros", "net", "rt-multi-thread", "signal", "time"] }
+tokio = { version = "1.12.0", features = ["io-util", "macros", "net", "rt", "signal", "time"] }
 futures = "0.3.17"

--- a/examples/tcp-echo-server.rs
+++ b/examples/tcp-echo-server.rs
@@ -75,7 +75,7 @@ async fn handle_client(shutdown: ShutdownManager<i32>, mut stream: TcpStream, ad
 		Err(_) => {
 			eprintln!("Shutdown already started, closing connection with {}", address);
 			return;
-		}
+		},
 	};
 
 	// Now run the echo loop, but cancel it when the shutdown is triggered.


### PR DESCRIPTION
For single-thread runtimes, the Mutex used in async-shutdown can interfere with the task reactor. This patch allows a default multi-thread runtime support via feature, and allows for single-thread support when default features are off.

The code is wrapped within a `LockGuard` which provides an interface similar to a `RefCell`.

In the single-thread mode, there isn't support for cross-thread shutdown signaling, that coordination is left to the user to implement.